### PR TITLE
Re-introdude ip-screen

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -28,7 +28,7 @@ Conflicts:
 Description: reusable core scripts for the Grml system
  This package includes some core scripts for the Grml system.
  .
- Currently, this package includes cpu-screen.
+ Currently, this package includes cpu-screen and ip-screen.
  .
  This package can be used on plain Debian systems as well. It is
  intended as a complement to grml-etc-core.

--- a/debian/grml-scripts-core.links
+++ b/debian/grml-scripts-core.links
@@ -1,1 +1,2 @@
 /usr/share/man/man1/grml-scripts-core.1.gz /usr/share/man/man1/cpu-screen.1.gz
+/usr/share/man/man1/grml-scripts-core.1.gz /usr/share/man/man1/ip-screen.1.gz

--- a/manpages/grml-scripts-core.1
+++ b/manpages/grml-scripts-core.1
@@ -15,6 +15,9 @@ grml\-scripts\-core \- core script collection for the Grml distribution
 .SS cpu-screen
 output current / available cpu frequencies
 (useful for integration into GNU screen)
+.SS ip-screen
+print ip address (IPv4 only) of configured network interfaces to stdout
+(useful for integration into GNU screen)
 
 .SH "BUGS"
 Probably. Please report any bugs you find and report
@@ -26,7 +29,7 @@ Thank you!
 screen(1), grml-scripts(8)
 
 .SH "COPYRIGHT"
-This man page is copyright \(co 2004-2011 by the Grml team.
+This man page is copyright \(co 2004-2024 by the Grml team.
 Included scripts are under various copyrights, please see
 the sources.
 .\"###### END OF FILE ##########################################################

--- a/usr_bin/ip-screen
+++ b/usr_bin/ip-screen
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Filename:      ip-screen
+# Purpose:       output ip address (IPv4 only) of configured network interfaces (useful for integration into GNU screen)
+# Authors:       grml-team (grml.org), (c) Darshaka Pathirana <dpat@grml.org>
+# Bug-Reports:   see http://grml.org/bugs/
+# License:       This file is licensed under the GPL v2.
+#******************************************************************************
+
+hostname -I | sed -e 's/ [^ ]*:.*$//;s/ / | /g;s/ | $//'


### PR DESCRIPTION
In 8bc8f27 we decided to drop ip-screen in favor of hostname -I + sed, and put the command pair in our screenrc in grml-etc-core to make grml-scripts-core fit for ARM, see: grml/grml-scripts-core#3.

In grml/grml-etc-core#162 I tried to replace ip-screen in our screenrc with the hostname -I + sed command pair, but it turned out that to use it in the backtick command, we need to use "sh -c" and escape "`^`" with "`\^`".

So in the end we decided to re-introdue ip-screen as a wrapper script for hostname + sed.

Updated the copyright date too.

This partly reverts commit 8bc8f2770edf9c389f5bf3c2b5e0493ff1340d21.

Closes: grml/grml-etc-core#162